### PR TITLE
fix: getChildren returns Array now in applyContrastFilter.js

### DIFF
--- a/applyContrastFilter.js
+++ b/applyContrastFilter.js
@@ -5,7 +5,7 @@ function hasChildren(node) {
 
 function getChildren(node) {
   // get node children return list of nodes value
-  return node.children;
+  return [...node.children];
 }
 
 function hasPositionFixed(node) {


### PR DESCRIPTION
We need to destruct to Array this, because "children" property is not Array.